### PR TITLE
(feature/cmd2) Implement shell using cmd2.Cmd (fix #26)

### DIFF
--- a/pycdsl/cli.py
+++ b/pycdsl/cli.py
@@ -10,7 +10,12 @@ import argparse
 
 from .corpus import CDSLCorpus
 from .shell import CDSLShell
-from .constants import DEFAULT_SCHEME, DEFAULT_SEARCH_MODE
+from .constants import (
+    DEFAULT_SCHEME,
+    DEFAULT_SEARCH_MODE,
+    DEFAULT_HISTORY_FILE,
+    DEFAULT_STARTUP_SCRIPT
+)
 from . import __version__
 
 ###############################################################################
@@ -70,6 +75,18 @@ def main():
         help="output transliteration scheme"
     )
     parser.add_argument(
+        "-hf",
+        "--history-file",
+        default=DEFAULT_HISTORY_FILE,
+        help="path to the history file"
+    )
+    parser.add_argument(
+        "-sc",
+        "--startup-script",
+        default=DEFAULT_STARTUP_SCRIPT,
+        help="path to the startup script"
+    )
+    parser.add_argument(
         "-u",
         "--update",
         action="store_true",
@@ -98,6 +115,9 @@ def main():
     input_scheme = args.get("input_scheme")
     output_scheme = args.get("output_scheme")
 
+    history_file = args.get("history_file")
+    startup_script = args.get("startup_script")
+
     flag_update = args.get("update")
     flag_debug = args.get("debug")
     flag_interactive = args.get("interactive")
@@ -115,10 +135,12 @@ def main():
             dict_ids=dict_ids,
             search_mode=search_mode,
             input_scheme=input_scheme,
-            output_scheme=output_scheme
+            output_scheme=output_scheme,
+            history_file=history_file,
+            startup_script=startup_script
         )
         cdsl_shell.cdsl.setup(dict_ids=dict_ids, update=flag_update)
-        cdsl_shell.cmdloop()
+        return cdsl_shell.cmdloop()
     else:
         # non-interactive shell command
         cdsl = CDSLCorpus(

--- a/pycdsl/constants.py
+++ b/pycdsl/constants.py
@@ -55,4 +55,7 @@ ENGLISH_DICTIONARIES = ["MWE", "BOR", "AE"]
 HOME_DIR = Path.home()
 DEFAULT_CORPUS_DIR = HOME_DIR / "cdsl_data"
 
+DEFAULT_HISTORY_FILE = HOME_DIR / ".cdsl_history"
+DEFAULT_STARTUP_SCRIPT = HOME_DIR / ".cdslrc"
+
 ###############################################################################

--- a/pycdsl/shell.py
+++ b/pycdsl/shell.py
@@ -97,7 +97,7 @@ class CDSLShell(BasicShell):
             If None, no startup commands are run.
             The default is None.
         """
-        super(self.__class__, self).__init__(
+        super().__init__(
             persistent_history_file=history_file,
             startup_script=startup_script,
             allow_cli_args=False

--- a/pycdsl/shell.py
+++ b/pycdsl/shell.py
@@ -4,7 +4,7 @@
 
 ###############################################################################
 
-import logging
+# import logging
 from typing import List
 
 import cmd2
@@ -142,25 +142,25 @@ class CDSLShell(BasicShell):
         self.dict_ids = dict_ids
         self.active_dicts = None
 
-        # Logging
-        self.logger = logging.getLogger()  # root logger
-        if not self.logger.hasHandlers():
-            self.logger.addHandler(logging.StreamHandler())
-        self.logger.setLevel(logging.INFO)
+        # # Logging
+        # self.logger = logging.getLogger()  # root logger
+        # if not self.logger.hasHandlers():
+        #     self.logger.addHandler(logging.StreamHandler())
+        # self.logger.setLevel(logging.INFO)
 
     # ----------------------------------------------------------------------- #
     # Debug Mode
 
-    def do_debug(self, arg: str):
-        """Turn debug mode on/off"""
-        arg = arg.lower()
-        if arg in ["true", "on", "yes"]:
-            self.debug = True
-            self.logger.setLevel(logging.DEBUG)
-        if arg in ["false", "off", "no"]:
-            self.debug = False
-            self.logger.setLevel(logging.INFO)
-        print(f"Debug: {self.debug}")
+    # def do_debug(self, arg: str):
+    #     """Turn debug mode on/off"""
+    #     arg = arg.lower()
+    #     if arg in ["true", "on", "yes"]:
+    #         self.debug = True
+    #         self.logger.setLevel(logging.DEBUG)
+    #     if arg in ["false", "off", "no"]:
+    #         self.debug = False
+    #         self.logger.setLevel(logging.INFO)
+    #     print(f"Debug: {self.debug}")
 
     # ----------------------------------------------------------------------- #
     # Input/Output Transliteration Scheme
@@ -345,7 +345,7 @@ class CDSLShell(BasicShell):
                             transliterate_keys=active_dict.transliterate_keys
                         )
                     )
-                    self.logger.debug(f"Data: {result.data}")
+                    # self.logger.debug(f"Data: {result.data}")
                 except Exception:
                     result = None
 

--- a/pycdsl/shell.py
+++ b/pycdsl/shell.py
@@ -4,11 +4,10 @@
 
 ###############################################################################
 
-import os
-import cmd
 import logging
 from typing import List
 
+import cmd2
 from indic_transliteration import sanscript
 from indic_transliteration.sanscript import transliterate
 
@@ -25,21 +24,10 @@ from . import __version__
 ###############################################################################
 
 
-class BasicShell(cmd.Cmd):
-    def emptyline(self):
-        pass
+class BasicShell(cmd2.Cmd):
+    delattr(cmd2.Cmd, "do_edit")
+    delattr(cmd2.Cmd, "do_run_pyscript")
 
-    def do_shell(self, commad):
-        """Execute shell commands"""
-        os.system(commad)
-
-    def do_exit(self, arg):
-        """Exit the shell"""
-        print("Bye")
-        return True
-
-    # do_EOF corresponds to Ctrl + D
-    do_EOF = do_exit
 
 ###############################################################################
 
@@ -55,13 +43,26 @@ class CDSLShell(BasicShell):
            "(help or ? for list of options)"
     prompt = "(CDSL::None) "
 
+    schemes = [
+        sanscript.DEVANAGARI,
+        sanscript.IAST,
+        sanscript.ITRANS,
+        sanscript.VELTHUIS,
+        sanscript.HK,
+        sanscript.SLP1,
+        sanscript.WX,
+    ]
+    search_modes = SEARCH_MODES
+
     def __init__(
         self,
         data_dir: str = None,
         dict_ids: List[str] = None,
         search_mode: str = None,
         input_scheme: str = None,
-        output_scheme: str = None
+        output_scheme: str = None,
+        history_file: str = None,
+        startup_script: str = None
     ):
         """REPL Interface to CDSL
 
@@ -87,26 +88,51 @@ class CDSLShell(BasicShell):
             Transliteration scheme for output.
             If None, `DEFAULT_SCHEME` is used.
             The default is None.
+        history_file : str or None, optional
+            Path to the history file to keep a persistant history.
+            If None, the history does not persist across sessions.
+            The default is None.
+        startup_script : str or None, optional
+            Path to the startup script with a list of startup commands
+            to be executed after initialization.
+            If None, no startup commands are run.
+            The default is None.
         """
-        super(self.__class__, self).__init__()
-        self.debug = False
-        self.schemes = [
-            sanscript.DEVANAGARI,
-            sanscript.IAST,
-            sanscript.ITRANS,
-            sanscript.VELTHUIS,
-            sanscript.HK,
-            sanscript.SLP1,
-            sanscript.WX,
+        super(self.__class__, self).__init__(
+            persistent_history_file=history_file,
+            startup_script=startup_script,
+            allow_cli_args=False
+        )
+        self.default_category = "Utility Commands"
+        remove_settables = [
+            "always_show_hint",
+            "echo",
+            "editor",
+            "feedback_to_output",
+            "max_completion_items",
         ]
-        self.search_modes = SEARCH_MODES
+        for settable in remove_settables:
+            self.remove_settable(settable)
 
+        # ------------------------------------------------------------------- #
+        # Settings
+
+        # Search Mode
         self.search_mode = (
             validate_search_mode(search_mode) or DEFAULT_SEARCH_MODE
         )
+
+        # Transliteration Schemes
         self.input_scheme = validate_scheme(input_scheme) or DEFAULT_SCHEME
         self.output_scheme = validate_scheme(output_scheme) or DEFAULT_SCHEME
 
+        # Search parameters
+        self.limit = 50
+        self.offset = None
+
+        # ------------------------------------------------------------------- #
+
+        # Corpus Initialisation
         self.cdsl = CDSLCorpus(
             data_dir=data_dir,
             search_mode=None,
@@ -115,10 +141,6 @@ class CDSLShell(BasicShell):
         )
         self.dict_ids = dict_ids
         self.active_dicts = None
-
-        # Search parameters
-        self.limit = 50
-        self.offset = None
 
         # Logging
         self.logger = logging.getLogger()  # root logger
@@ -149,27 +171,33 @@ class CDSLShell(BasicShell):
     def complete_output_scheme(self, text, line, begidx, endidx):
         return [sch for sch in self.schemes if sch.startswith(text)]
 
-    def do_input_scheme(self, scheme: str):
+    @cmd2.with_category("CDSL Settings")
+    def do_input_scheme(self, scheme: cmd2.Statement):
         """Change the input transliteration scheme"""
         if not scheme:
-            print(f"Input scheme: {self.input_scheme}")
+            self.poutput(f"Input scheme: {self.input_scheme}")
         else:
             if scheme not in self.schemes:
-                print(f"Invalid scheme. (valid schemes are {self.schemes})")
+                self.pwarning(
+                    f"Invalid scheme. (valid schemes are {self.schemes})"
+                )
             else:
                 self.input_scheme = scheme
-                print(f"Input scheme set to '{self.input_scheme}'.")
+                self.poutput(f"Input scheme set to '{self.input_scheme}'.")
 
-    def do_output_scheme(self, scheme: str):
+    @cmd2.with_category("CDSL Settings")
+    def do_output_scheme(self, scheme: cmd2.Statement):
         """Change the output transliteration scheme"""
         if not scheme:
-            print(f"Output scheme: {self.output_scheme}")
+            self.poutput(f"Output scheme: {self.output_scheme}")
         else:
             if scheme not in self.schemes:
-                print(f"Invalid scheme. (valid schemes are {self.schemes}")
+                self.pwarning(
+                    f"Invalid scheme. (valid schemes are {self.schemes}"
+                )
             else:
                 self.output_scheme = scheme
-                print(f"Output scheme set to '{self.output_scheme}'.")
+                self.poutput(f"Output scheme set to '{self.output_scheme}'.")
 
     # ----------------------------------------------------------------------- #
     # Search Mode
@@ -177,69 +205,83 @@ class CDSLShell(BasicShell):
     def complete_search_mode(self, text, line, begidx, endidx):
         return [sch for sch in self.search_modes if sch.startswith(text)]
 
-    def do_search_mode(self, mode: str):
+    @cmd2.with_category("CDSL Settings")
+    def do_search_mode(self, mode: cmd2.Statement):
         """Change the search mode"""
         if not mode:
-            print(f"Search mode: {self.search_mode}")
+            self.poutput(f"Search mode: {self.search_mode}")
         else:
-            if mode not in self.search_modes:
-                print(f"Invalid mode. (valid modes are {self.search_modes})")
+            if validate_search_mode(mode) is None:
+                self.pwarning(
+                    f"Invalid mode. (valid modes are {self.search_modes})"
+                )
             else:
-                self.search_mode = mode
-                print(f"Search mode set to '{self.search_mode}'.")
+                self.search_mode = validate_search_mode(mode)
+                self.poutput(f"Search mode set to '{self.search_mode}'.")
 
     # ----------------------------------------------------------------------- #
     # Dictionary Information
 
-    def do_info(self, text: str = None):
+    @cmd2.with_category("CDSL Core Commands")
+    def do_info(self, _: cmd2.Statement):
         """Display information about active dictionaries"""
         if self.active_dicts is None:
-            self.logger.error("Please select a dictionary first.")
+            self.perror("Please select a dictionary first.")
         else:
-            print(f"Total {len(self.active_dicts)} dictionaries are active.")
+            self.poutput(
+                f"Total {len(self.active_dicts)} dictionaries are active."
+            )
             for active_dict in self.active_dicts:
-                print(active_dict)
+                self.poutput(active_dict)
 
-    def do_stats(self, text: str = None):
+    @cmd2.with_category("CDSL Core Commands")
+    def do_stats(self, _: cmd2.Statement):
         """Display statistics about active dictionaries"""
         if self.active_dicts is None:
-            self.logger.error("Please select a dictionary first.")
+            self.perror("Please select a dictionary first.")
         else:
-            print(f"Total {len(self.active_dicts)} dictionaries are active.")
+            self.poutput(
+                f"Total {len(self.active_dicts)} dictionaries are active."
+            )
             for active_dict in self.active_dicts:
-                print("---")
-                print(active_dict)
-                print(active_dict.stats(output_scheme=self.output_scheme))
+                self.poutput("---")
+                self.poutput(active_dict)
+                self.poutput(
+                    active_dict.stats(output_scheme=self.output_scheme)
+                )
 
     # ----------------------------------------------------------------------- #
 
-    def do_dicts(self, text: str = None):
+    @cmd2.with_category("CDSL Core Commands")
+    def do_dicts(self, _: cmd2.Statement):
         """Display a list of dictionaries available locally"""
         for _, cdsl_dict in self.cdsl.dicts.items():
-            print(cdsl_dict)
+            self.poutput(cdsl_dict)
 
-    def do_available(self, text: str = None):
+    @cmd2.with_category("CDSL Core Commands")
+    def do_available(self, _: cmd2.Statement):
         """Display a list of dictionaries available in CDSL"""
         for _, cdsl_dict in self.cdsl.available_dicts.items():
-            print(cdsl_dict)
+            self.poutput(cdsl_dict)
 
     # ----------------------------------------------------------------------- #
 
-    def do_update(self, text: str = None):
+    @cmd2.with_category("CDSL Core Commands")
+    def do_update(self, _: cmd2.Statement):
         """Update loaded dictionaries"""
         self.cdsl.setup(list(self.cdsl.dicts), update=True)
 
     # ----------------------------------------------------------------------- #
 
     def complete_use(self, text, line, begidx, endidx):
-        last_word = text.upper().rsplit(maxsplit=1)[-1] if text else ""
         return [
             dict_id
             for dict_id in self.cdsl.available_dicts
-            if dict_id.startswith(last_word)
+            if dict_id.startswith(text.upper())
         ]
 
-    def do_use(self, line: str):
+    @cmd2.with_category("CDSL Core Commands")
+    def do_use(self, line: cmd2.Statement):
         """
         Load the specified dictionaries from CDSL.
         If not available locally, they will be installed first.
@@ -249,7 +291,7 @@ class CDSLShell(BasicShell):
         """
         line = line.upper().strip()
         if not line:
-            print("Please provide dictionary ID(s) to use.")
+            self.perror("Please provide dictionary ID(s) to use.")
             return
         if line == "NONE":
             self.active_dicts = []
@@ -258,7 +300,7 @@ class CDSLShell(BasicShell):
             if status:
                 self.active_dicts = self.cdsl.dicts.values()
             else:
-                self.logger.error("Couldn't setup some dictionary.")
+                self.perror("Couldn't setup some dictionary.")
         else:
             dict_ids = line.split()
             self.active_dicts = []
@@ -269,14 +311,14 @@ class CDSLShell(BasicShell):
                 if status:
                     self.active_dicts.append(self.cdsl.dicts[dict_id])
                 else:
-                    self.logger.error(
+                    self.perror(
                         f"Couldn't setup dictionary '{dict_id}'."
                     )
 
         active_count = len(self.active_dicts)
         active_ids = [active_dict.id for active_dict in self.active_dicts]
 
-        print(f"Using {active_count} dictionaries: {active_ids}")
+        self.poutput(f"Using {active_count} dictionaries: {active_ids}")
 
         if active_count == 0:
             active_prompt = "None"
@@ -288,15 +330,16 @@ class CDSLShell(BasicShell):
 
     # ----------------------------------------------------------------------- #
 
-    def do_show(self, entry_id: str):
+    @cmd2.with_category("CDSL Core Commands")
+    def do_show(self, entry_id: cmd2.Statement):
         """Show a specific entry by ID"""
         if self.active_dicts is None:
-            self.logger.error("Please select a dictionary first.")
+            self.perror("Please select a dictionary first.")
         else:
             for active_dict in self.active_dicts:
                 try:
                     result = active_dict.entry(entry_id)
-                    print(
+                    self.poutput(
                         result.transliterate(
                             scheme=self.output_scheme,
                             transliterate_keys=active_dict.transliterate_keys
@@ -307,34 +350,36 @@ class CDSLShell(BasicShell):
                     result = None
 
                 if result is None:
-                    self.logger.warning(
+                    self.perror(
                         f"Entry {entry_id} not found in '{active_dict.id}'."
                     )
 
     # ----------------------------------------------------------------------- #
 
-    def do_limit(self, text: str):
+    @cmd2.with_category("CDSL Settings")
+    def do_limit(self, text: cmd2.Statement):
         """Limit the number of search results per dictionary"""
         if text:
             try:
                 self.limit = int(text.strip())
                 if self.limit < 1:
                     self.limit = None
-                print(f"Limit set to '{self.limit}'.")
+                self.poutput(f"Limit set to {self.limit}.")
             except Exception:
-                self.logger.error("Limit must be an integer.")
+                self.pwarning("Limit must be an integer.")
         else:
-            print(f"Limit: {self.limit}")
+            self.poutput(f"Limit: {self.limit}")
 
     # ----------------------------------------------------------------------- #
 
-    def do_version(self, text: str = None):
+    def do_version(self, _: cmd2.Statement):
         """Show the current version of PyCDSL"""
-        print(f"PyCDSL v{__version__}")
+        self.poutput(f"PyCDSL v{__version__}")
 
     # ----------------------------------------------------------------------- #
 
-    def do_search(self, line: str):
+    @cmd2.with_category("CDSL Core Commands")
+    def do_search(self, line: cmd2.Statement):
         """
         Search in the active dictionaries
 
@@ -346,7 +391,7 @@ class CDSLShell(BasicShell):
           `version`, `help` etc. in the active dictionaries.
         """
         if self.active_dicts is None:
-            self.logger.error("Please select a dictionary first.")
+            self.perror("Please select a dictionary first.")
         else:
             for active_dict in self.active_dicts:
                 search_pattern = transliterate(
@@ -360,10 +405,11 @@ class CDSLShell(BasicShell):
                 if not results:
                     continue
 
-                print(f"\nFound {len(results)} results in {active_dict.id}.\n")
-
+                self.poutput(
+                    f"\nFound {len(results)} results in {active_dict.id}.\n"
+                )
                 for result in results:
-                    print(
+                    self.poutput(
                         result.transliterate(
                             scheme=self.output_scheme,
                             transliterate_keys=active_dict.transliterate_keys
@@ -372,17 +418,17 @@ class CDSLShell(BasicShell):
 
     # ----------------------------------------------------------------------- #
 
-    def default(self, line: str):
-        self.do_search(line)
+    def default(self, statement: cmd2.Statement):
+        self.do_search(statement.raw)
 
     # ----------------------------------------------------------------------- #
 
-    def cmdloop(self, intro: str = None):
-        print(self.intro)
-        print(self.desc)
+    def cmdloop(self, intro: cmd2.Statement = None):
+        self.poutput(self.intro)
+        self.poutput(self.desc)
         self.cdsl.setup(dict_ids=self.dict_ids)
 
-        print(f"Loaded {len(self.cdsl.dicts)} dictionaries.")
+        self.poutput(f"Loaded {len(self.cdsl.dicts)} dictionaries.")
 
         if self.dict_ids is not None:
             self.do_use(" ".join(self.dict_ids))
@@ -392,7 +438,7 @@ class CDSLShell(BasicShell):
                 super(self.__class__, self).cmdloop(intro="")
                 break
             except KeyboardInterrupt:
-                print("\nKeyboardInterrupt")
+                self.poutput("\nKeyboardInterrupt")
 
 
 ###############################################################################

--- a/pycdsl/shell.py
+++ b/pycdsl/shell.py
@@ -342,9 +342,14 @@ class CDSLShell(BasicShell):
 
     # ----------------------------------------------------------------------- #
 
+    search_parser = cmd2.Cmd2ArgumentParser()
+    search_parser.add_argument("pattern", type=str, help="search pattern")
+    search_parser.add_argument("--limit", type=int, help="limit results")
+    search_parser.add_argument("--offset", type=int, help="skip results")
 
     @cmd2.with_category("Core")
-    def do_search(self, line: cmd2.Statement):
+    @cmd2.with_argparser(search_parser)
+    def do_search(self, statement: cmd2.argparse.Namespace):
         """
         Search in the active dictionaries
 
@@ -358,14 +363,19 @@ class CDSLShell(BasicShell):
         if self.active_dicts is None:
             self.perror("Please select a dictionary first.")
         else:
+            pattern = statement.pattern
+            offset = statement.offset
+            limit = statement.limit or self.limit
+
             for active_dict in self.active_dicts:
                 search_pattern = transliterate(
-                    line, self.input_scheme, INTERNAL_SCHEME
-                ) if active_dict.transliterate_keys else line
+                    pattern, self.input_scheme, INTERNAL_SCHEME
+                ) if active_dict.transliterate_keys else pattern
                 results = active_dict.search(
                     search_pattern,
                     mode=self.search_mode,
-                    limit=self.limit
+                    limit=limit,
+                    offset=offset
                 )
                 if not results:
                     continue

--- a/pycdsl/shell.py
+++ b/pycdsl/shell.py
@@ -104,6 +104,7 @@ class CDSLShell(BasicShell):
         )
         self.default_category = "Utility"
         remove_settables = [
+            "allow_style",
             "always_show_hint",
             "echo",
             "editor",
@@ -132,7 +133,7 @@ class CDSLShell(BasicShell):
         self.add_settable(
             cmd2.utils.Settable(
                 "search_mode",
-                str,
+                str.lower,
                 "Search mode",
                 self,
                 choices=self.search_modes
@@ -141,7 +142,7 @@ class CDSLShell(BasicShell):
         self.add_settable(
             cmd2.utils.Settable(
                 "input_scheme",
-                str,
+                str.lower,
                 "Input transliteration scheme",
                 self,
                 choices=self.schemes
@@ -150,7 +151,7 @@ class CDSLShell(BasicShell):
         self.add_settable(
             cmd2.utils.Settable(
                 "output_scheme",
-                str,
+                str.lower,
                 "Output transliteration scheme",
                 self,
                 choices=self.schemes
@@ -159,10 +160,9 @@ class CDSLShell(BasicShell):
         self.add_settable(
             cmd2.utils.Settable(
                 "limit",
-                int,
+                lambda x: int(x) if int(x) > 0 else None,
                 "Limit search results",
-                self,
-                onchange_cb=self._limit_handler
+                self
             )
         )
 
@@ -177,12 +177,6 @@ class CDSLShell(BasicShell):
         )
         self.dict_ids = dict_ids
         self.active_dicts = None
-
-    # ----------------------------------------------------------------------- #
-
-    def _limit_handler(self, name, old_value, new_value):
-        if new_value < 0:
-            self.limit = None
 
     # ----------------------------------------------------------------------- #
     # Dictionary Information

--- a/pycdsl/shell.py
+++ b/pycdsl/shell.py
@@ -130,6 +130,43 @@ class CDSLShell(BasicShell):
         self.limit = 50
         self.offset = None
 
+        self.add_settable(
+            cmd2.utils.Settable(
+                "search_mode",
+                str,
+                "Search mode",
+                self,
+                choices=self.search_modes
+            )
+        )
+        self.add_settable(
+            cmd2.utils.Settable(
+                "input_scheme",
+                str,
+                "Input transliteration scheme",
+                self,
+                choices=self.schemes
+            )
+        )
+        self.add_settable(
+            cmd2.utils.Settable(
+                "output_scheme",
+                str,
+                "Output transliteration scheme",
+                self,
+                choices=self.schemes
+            )
+        )
+        self.add_settable(
+            cmd2.utils.Settable(
+                "limit",
+                int,
+                "Limit search results",
+                self,
+                onchange_cb=self._limit_handler
+            )
+        )
+
         # ------------------------------------------------------------------- #
 
         # Corpus Initialisation
@@ -163,61 +200,10 @@ class CDSLShell(BasicShell):
     #     print(f"Debug: {self.debug}")
 
     # ----------------------------------------------------------------------- #
-    # Input/Output Transliteration Scheme
 
-    def complete_input_scheme(self, text, line, begidx, endidx):
-        return [sch for sch in self.schemes if sch.startswith(text)]
-
-    def complete_output_scheme(self, text, line, begidx, endidx):
-        return [sch for sch in self.schemes if sch.startswith(text)]
-
-    @cmd2.with_category("CDSL Settings")
-    def do_input_scheme(self, scheme: cmd2.Statement):
-        """Change the input transliteration scheme"""
-        if not scheme:
-            self.poutput(f"Input scheme: {self.input_scheme}")
-        else:
-            if scheme not in self.schemes:
-                self.pwarning(
-                    f"Invalid scheme. (valid schemes are {self.schemes})"
-                )
-            else:
-                self.input_scheme = scheme
-                self.poutput(f"Input scheme set to '{self.input_scheme}'.")
-
-    @cmd2.with_category("CDSL Settings")
-    def do_output_scheme(self, scheme: cmd2.Statement):
-        """Change the output transliteration scheme"""
-        if not scheme:
-            self.poutput(f"Output scheme: {self.output_scheme}")
-        else:
-            if scheme not in self.schemes:
-                self.pwarning(
-                    f"Invalid scheme. (valid schemes are {self.schemes}"
-                )
-            else:
-                self.output_scheme = scheme
-                self.poutput(f"Output scheme set to '{self.output_scheme}'.")
-
-    # ----------------------------------------------------------------------- #
-    # Search Mode
-
-    def complete_search_mode(self, text, line, begidx, endidx):
-        return [sch for sch in self.search_modes if sch.startswith(text)]
-
-    @cmd2.with_category("CDSL Settings")
-    def do_search_mode(self, mode: cmd2.Statement):
-        """Change the search mode"""
-        if not mode:
-            self.poutput(f"Search mode: {self.search_mode}")
-        else:
-            if validate_search_mode(mode) is None:
-                self.pwarning(
-                    f"Invalid mode. (valid modes are {self.search_modes})"
-                )
-            else:
-                self.search_mode = validate_search_mode(mode)
-                self.poutput(f"Search mode set to '{self.search_mode}'.")
+    def _limit_handler(self, name, old_value, new_value):
+        if new_value < 0:
+            self.limit = None
 
     # ----------------------------------------------------------------------- #
     # Dictionary Information
@@ -356,27 +342,7 @@ class CDSLShell(BasicShell):
 
     # ----------------------------------------------------------------------- #
 
-    @cmd2.with_category("CDSL Settings")
-    def do_limit(self, text: cmd2.Statement):
-        """Limit the number of search results per dictionary"""
-        if text:
-            try:
-                self.limit = int(text.strip())
-                if self.limit < 1:
-                    self.limit = None
-                self.poutput(f"Limit set to {self.limit}.")
-            except Exception:
-                self.pwarning("Limit must be an integer.")
-        else:
-            self.poutput(f"Limit: {self.limit}")
 
-    # ----------------------------------------------------------------------- #
-
-    def do_version(self, _: cmd2.Statement):
-        """Show the current version of PyCDSL"""
-        self.poutput(f"PyCDSL v{__version__}")
-
-    # ----------------------------------------------------------------------- #
 
     @cmd2.with_category("CDSL Core Commands")
     def do_search(self, line: cmd2.Statement):
@@ -440,5 +406,10 @@ class CDSLShell(BasicShell):
             except KeyboardInterrupt:
                 self.poutput("\nKeyboardInterrupt")
 
+    # ----------------------------------------------------------------------- #
+
+    def do_version(self, _: cmd2.Statement):
+        """Show the current version of PyCDSL"""
+        self.poutput(f"PyCDSL v{__version__}")
 
 ###############################################################################

--- a/pycdsl/shell.py
+++ b/pycdsl/shell.py
@@ -103,7 +103,7 @@ class CDSLShell(BasicShell):
             startup_script=startup_script,
             allow_cli_args=False
         )
-        self.default_category = "Utility Commands"
+        self.default_category = "Utility"
         remove_settables = [
             "always_show_hint",
             "echo",
@@ -208,7 +208,7 @@ class CDSLShell(BasicShell):
     # ----------------------------------------------------------------------- #
     # Dictionary Information
 
-    @cmd2.with_category("CDSL Core Commands")
+    @cmd2.with_category("Core")
     def do_info(self, _: cmd2.Statement):
         """Display information about active dictionaries"""
         if self.active_dicts is None:
@@ -220,7 +220,7 @@ class CDSLShell(BasicShell):
             for active_dict in self.active_dicts:
                 self.poutput(active_dict)
 
-    @cmd2.with_category("CDSL Core Commands")
+    @cmd2.with_category("Core")
     def do_stats(self, _: cmd2.Statement):
         """Display statistics about active dictionaries"""
         if self.active_dicts is None:
@@ -238,13 +238,13 @@ class CDSLShell(BasicShell):
 
     # ----------------------------------------------------------------------- #
 
-    @cmd2.with_category("CDSL Core Commands")
+    @cmd2.with_category("Core")
     def do_dicts(self, _: cmd2.Statement):
         """Display a list of dictionaries available locally"""
         for _, cdsl_dict in self.cdsl.dicts.items():
             self.poutput(cdsl_dict)
 
-    @cmd2.with_category("CDSL Core Commands")
+    @cmd2.with_category("Core")
     def do_available(self, _: cmd2.Statement):
         """Display a list of dictionaries available in CDSL"""
         for _, cdsl_dict in self.cdsl.available_dicts.items():
@@ -252,7 +252,7 @@ class CDSLShell(BasicShell):
 
     # ----------------------------------------------------------------------- #
 
-    @cmd2.with_category("CDSL Core Commands")
+    @cmd2.with_category("Core")
     def do_update(self, _: cmd2.Statement):
         """Update loaded dictionaries"""
         self.cdsl.setup(list(self.cdsl.dicts), update=True)
@@ -266,7 +266,7 @@ class CDSLShell(BasicShell):
             if dict_id.startswith(text.upper())
         ]
 
-    @cmd2.with_category("CDSL Core Commands")
+    @cmd2.with_category("Core")
     def do_use(self, line: cmd2.Statement):
         """
         Load the specified dictionaries from CDSL.
@@ -316,7 +316,7 @@ class CDSLShell(BasicShell):
 
     # ----------------------------------------------------------------------- #
 
-    @cmd2.with_category("CDSL Core Commands")
+    @cmd2.with_category("Core")
     def do_show(self, entry_id: cmd2.Statement):
         """Show a specific entry by ID"""
         if self.active_dicts is None:
@@ -343,8 +343,7 @@ class CDSLShell(BasicShell):
     # ----------------------------------------------------------------------- #
 
 
-
-    @cmd2.with_category("CDSL Core Commands")
+    @cmd2.with_category("Core")
     def do_search(self, line: cmd2.Statement):
         """
         Search in the active dictionaries

--- a/pycdsl/shell.py
+++ b/pycdsl/shell.py
@@ -305,12 +305,21 @@ class CDSLShell(BasicShell):
 
     # ----------------------------------------------------------------------- #
 
+    show_parser = cmd2.Cmd2ArgumentParser()
+    show_parser.add_argument("entry_id", type=int, help="entry ID to show")
+    show_parser.add_argument(
+        "--show-data", action="store_true", help="show XML data field"
+    )
+
     @cmd2.with_category("Core")
-    def do_show(self, entry_id: cmd2.Statement):
+    @cmd2.with_argparser(show_parser)
+    def do_show(self, namespace: cmd2.argparse.Namespace):
         """Show a specific entry by ID"""
         if self.active_dicts is None:
             self.perror("Please select a dictionary first.")
         else:
+            entry_id = namespace.entry_id
+            show_data = namespace.show_data
             for active_dict in self.active_dicts:
                 try:
                     result = active_dict.entry(entry_id)
@@ -320,7 +329,8 @@ class CDSLShell(BasicShell):
                             transliterate_keys=active_dict.transliterate_keys
                         )
                     )
-                    # self.logger.debug(f"Data: {result.data}")
+                    if show_data:
+                        self.poutput(f"\nData:\n{result.data}")
                 except Exception:
                     result = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4>=4.10.0
 lxml>=4.6.2
 indic_transliteration>=2.2.4
 peewee>=3.14.4
+cmd2>=2.4.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,4 @@ twine==1.14.0
 
 pytest==6.2.4
 black==21.7b0
+cmd2_ext_test==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "pyreadline3; platform_system == 'Windows'",
 ]
 
-test_requirements = ['pytest>=3', ]
+test_requirements = ['pytest>=3', 'cmd2_ext_test>=2.0.0']
 
 setup(
     author="Hrishikesh Terdalkar",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ requirements = [
     'lxml>=4.6.2',
     'peewee>=3.14.4',
     'indic_transliteration>=2.2.4',
+    'cmd2>=2.4.1',
+    "pyreadline3; platform_system == 'Windows'",
 ]
 
 test_requirements = ['pytest>=3', ]

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,3 +1,63 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Tests for `pycdsl.shell`"""
+
+# https://pypi.org/project/cmd2-ext-test/
+
+import pytest
+import cmd2_ext_test
+
+from cmd2 import CommandResult
+
+from pycdsl.shell import CDSLShell
+
+###############################################################################
+
+
+class TestShell(cmd2_ext_test.ExternalTestMixin, CDSLShell):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture(scope="package")
+def sample_shell(default_path, installation_list):
+    shell = TestShell(data_dir=default_path, dict_ids=installation_list)
+    shell.fixture_setup()
+    yield shell
+    shell.fixture_teardown()
+
+###############################################################################
+
+
+def test_set(sample_shell):
+    sample_shell.app_cmd("set input_scheme iast")
+    assert sample_shell.input_scheme == "iast"
+    sample_shell.app_cmd("set input_scheme something-invalid")
+    assert sample_shell.input_scheme == "iast"
+    sample_shell.app_cmd("set output_scheme itrans")
+    assert sample_shell.output_scheme == "itrans"
+    sample_shell.app_cmd("set output_scheme something-invalid")
+    assert sample_shell.output_scheme == "itrans"
+    sample_shell.app_cmd("set search_mode value")
+    assert sample_shell.search_mode == "value"
+    sample_shell.app_cmd("set search_mode something-invalid")
+    assert sample_shell.search_mode == "value"
+    sample_shell.app_cmd("set limit 10")
+    assert sample_shell.limit == 10
+    sample_shell.app_cmd("set limit abc")
+    assert sample_shell.limit == 10
+    sample_shell.app_cmd("set limit -1")
+    assert sample_shell.limit is None
+
+
+def test_use(sample_shell):
+    output = sample_shell.app_cmd("use WIL")
+    assert isinstance(output, CommandResult)
+    assert str(output.stdout).strip() == "Using 1 dictionaries: ['WIL']"
+
+    output = sample_shell.app_cmd("use --none")
+    assert isinstance(output, CommandResult)
+    assert str(output.stdout).strip() == "Using 0 dictionaries: []"
+
+
+###############################################################################


### PR DESCRIPTION
## Description

Uses `cmd2.Cmd` as the base class for `CDSLShell`, instead of `BasicShell` (a custom extension of `cmd.Cmd`)

### Summary
- [x] Use `cmd2.Cmd` as base shell class
- [x] Persistent history
- [x] Startup script
- [x] Print output and warnings/errors using `poutput`, `perror`, `pwarning` methods of `cmd2.Cmd` instead of `print` and `logging`
- [x] ArgumentParser for `search()`, `use()`, `show()` (adds extra options)
  - [x] search: `--limit`, `--offset`
  - [x] show: `--show-data`
  - [x] use: `--all`, `--none`
- [x] Make `input_scheme`, `output_scheme`, `limit`, `search_mode` variables "settable" (using `cmd2.Cmd`'s `set` command)
- [ ] Tests

## Motivation and Context

Fixes #26 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

